### PR TITLE
Add ability to update git-based project

### DIFF
--- a/src/bin/devbox/commands/build.rs
+++ b/src/bin/devbox/commands/build.rs
@@ -12,7 +12,7 @@ pub fn exec(args: &ArgMatches) -> CliResult {
     let mut project = args.project()?;
 
     if let Some(name) = args.value_of("SERVICE") {
-        let mut service = project.find_service(name)?;
+        let service = project.find_service(name)?;
         let _ = service.clone_repo();
         service.build()
     } else {

--- a/src/bin/devbox/commands/mod.rs
+++ b/src/bin/devbox/commands/mod.rs
@@ -8,6 +8,7 @@ pub fn builtins() -> Vec<App> {
         logs::cli(),
         new::cli(),
         ps::cli(),
+        renew::cli(),
         start::cli(),
         stop::cli(),
         tasks::cli(),
@@ -23,6 +24,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&ArgMatches) -> CliResult> {
         "logs" => logs::exec,
         "new" => new::exec,
         "ps" => ps::exec,
+        "renew" => renew::exec,
         "start" => start::exec,
         "stop" => stop::exec,
         "tasks" => tasks::exec,
@@ -38,6 +40,7 @@ pub mod doctor;
 pub mod logs;
 pub mod new;
 pub mod ps;
+pub mod renew;
 pub mod start;
 pub mod stop;
 pub mod tasks;

--- a/src/bin/devbox/commands/renew.rs
+++ b/src/bin/devbox/commands/renew.rs
@@ -1,0 +1,22 @@
+use prelude::*;
+
+pub fn cli() -> App {
+    subcommand("renew")
+        .about("Re-generates an existing devbox project template from a git repository")
+        .arg(project())
+        .arg(
+            Arg::with_name("git")
+                .long("git")
+                .takes_value(true)
+                .required(true)
+                .help("A URL to a git repository containing configuration for this project"),
+        )
+}
+
+pub fn exec(args: &ArgMatches) -> CliResult {
+    let name = args.value_of("PROJECT")
+        .ok_or_else(|| format_err!("Missing project name"))?;
+    let repo = args.value_of("git")
+        .ok_or_else(|| format_err!("Missing git repository URL!"))?;
+    Project::update_from_git(name, repo)
+}


### PR DESCRIPTION
~~I moved the `new` command under a new `project` subcommand so that we could have more commands for working with projects grouped under that subcommand.~~

~~So instead of ~~

```
$ devbox new <NAME>
```

~~We have~~

```
$ devbox project new <NAME>
```

~~and~~

```
$ devbox project update <NAME>
```

~~Currently my version of the `update` command requires the git url to be passed again since we don't save it anywhere during the `new` command. I think it would be nice to make it optional, and reuse an existing url that we stash somewhere during `new`. I think we'd still have to always have the option, for existing projects that didn't have it saved, and I also think we'd want to have some way of updating the git url of an existing project in case you want to change it to a different branch or something. Maybe `devbox project config --git <url>` or something.~~

Adds a new `renew` command that re-generates (nay, copies/updates) a project config from a git repository so that existing projects can be updated. It requires passing the git url again since it is not stored anywhere.

(Fixes #3)